### PR TITLE
Updates to checkstyle configuration

### DIFF
--- a/gwt-checkstyle.xml
+++ b/gwt-checkstyle.xml
@@ -27,7 +27,6 @@ Description:
             <property name="max" value="100"/>
             <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
        </module>
-       <module name="FileContentsHolder" />
        <module name="InterfaceIsType">
             <property name="severity" value="ignore"/>
         </module>
@@ -53,7 +52,6 @@ Description:
         </module>
         <module name="LocalVariableName">
             <property name="severity" value="error"/>
-            <property name="tokens" value="PARAMETER_DEF,VARIABLE_DEF"/>
         </module>
         <module name="LeftCurly"/>
         <module name="RightCurly"/>
@@ -207,24 +205,24 @@ Description:
     <module name="JavadocPackage">
         <property name="severity" value="ignore"/>
     </module>
-        <module name="SuppressionCommentFilter">
+    <module name="SuppressWithPlainTextCommentFilter">
        <property name="offCommentFormat" value="CHECKSTYLE_OFF"/>
        <property name="onCommentFormat" value="CHECKSTYLE_ON"/>
     </module>
-    <module name="SuppressionCommentFilter">
-       <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
+    <module name="SuppressWithPlainTextCommentFilter">
+      <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
       <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
       <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
       <property name="checkFormat" value="MethodName"/>
     </module>
-    <module name="SuppressionCommentFilter">
-       <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
+    <module name="SuppressWithPlainTextCommentFilter">
+      <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
       <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
       <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
       <property name="checkFormat" value="MemberName"/>
     </module>
-    <module name="SuppressionCommentFilter">
-       <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
+    <module name="SuppressWithPlainTextCommentFilter">
+      <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
       <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
       <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
       <property name="checkFormat" value="ParameterName"/>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,13 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>8.8</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
By default, the maven-checkstyle-plugin (version 2.17) depends on checkstyle version 6.11.2.     The dependency has been updated to reflect the current latest version 8.8.
The previous version of checkstyle suppressed exceptions for missing check classes, etc.  Updating to latest brings these issues to the forefront, so modifications have been made to the gwt-checkstyle.xml file.

- FileContentsHolder was completely removed in Checkstyle 8.2.  Its only purpose (now done by other means) was to hold the current file contents for global access when configured as a TreeWalker sub-module.
- LocalVariableName no longer accepts tokens property
- SuppressionCommentFilter was deprecated in favor of SuppressWithPlainTextCommentFilter (see checkstyle 8.6 release notes: http://checkstyle.sourceforge.net/releasenotes.html#Release_8.6 )