### PR TITLE
Misc updates to checkstyle

### DIFF
--- a/gwt-checkstyle.xml
+++ b/gwt-checkstyle.xml
@@ -7,7 +7,7 @@ Checkstyle-Configuration: GWT Checks
 Description:
 
 -->
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
     <property name="severity" value="warning"/>
     <module name="RegexpHeader">

--- a/gwt-checkstyle.xml
+++ b/gwt-checkstyle.xml
@@ -25,7 +25,7 @@ Description:
        <property name="fileExtensions" value="java"/>
        <module name="LineLength">
             <property name="max" value="100"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|@link"/>
        </module>
        <module name="InterfaceIsType">
             <property name="severity" value="ignore"/>

--- a/gwt-checkstyle.xml
+++ b/gwt-checkstyle.xml
@@ -96,7 +96,7 @@ Description:
         </module>
         <module name="ImportOrder">
             <property name="severity" value="error"/>
-            <property name="groups" value="com.google, cern, com, junit, net, org, java, javax"/>
+            <property name="groups" value="org.gwtproject, com.google, cern, com, junit, net, org, java, javax"/>
             <property name="ordered" value="true"/>
             <property name="separated" value="true"/>
             <property name="option" value="top"/>


### PR DESCRIPTION
Added org.gwtproject as the first item to the ImportOrder check groups property, preceding com.google as modules being migrated to the new namespace should appear first

Updated the LineLength to ignore @link javadoc tags